### PR TITLE
Fix broken link

### DIFF
--- a/openshift-container-platform-3/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-3/policies/AC-Access_Control/component.yaml
@@ -243,8 +243,7 @@
         Documentation of OpenShift authorization frameworks and policies 
         can be found in the OpenShift Architecture documentation:
 
-        https://docs.openshift.com/container-platform/3.3/architecture/
-        additional_concepts/authorization.html
+        https://docs.openshift.com/container-platform/3.3/architecture/additional_concepts/authorization.html
 
         Each OpenShift deployment is unique in their rules, roles,
         policy bindings. This section should be updated with deployment
@@ -266,8 +265,8 @@
         <A review of OpenShift v3 networking can be found in the OpenShift
         Architecture guide:
 
-        https://docs.openshift.com/container-platform/3.3/architecture/
-        additional_concepts/networking.html'
+        https://docs.openshift.com/container-platform/3.3/architecture/additional_concepts/networking.html
+        '
 
 - control_key: AC-4 (21)
   standard_key: NIST-800-53


### PR DESCRIPTION
Line break in the middle of the url is little less common. So, it tends to break
parser that tries to render link nicely in github.com/RedHatGov/ocdb