### PR TITLE
Remove MA-6 (4) it does not (yet) exists

### DIFF
--- a/openstack-platform-13/policies/MA-Maintenance/component.yaml
+++ b/openstack-platform-13/policies/MA-Maintenance/component.yaml
@@ -140,6 +140,17 @@
 
         https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/435'
 
+- control_key: MA-4 (6)
+  standard_key: NIST-800-53
+  covered_by: []
+  implementation_status: planned
+  narrative:
+    - text: |
+        Documentation/guidance for this control is being
+        tracked on GitHub:
+
+        https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/436
+
 - control_key: MA-5
   standard_key: NIST-800-53
   covered_by: []
@@ -168,14 +179,3 @@
         on GitHub:
 
         https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/275'
-
-- control_key: MA-6 (4)
-  standard_key: NIST-800-53
-  covered_by: []
-  implementation_status: planned
-  narrative:
-    - text: |
-        'Documentation/guidance for this control is being
-        tracked on GitHub:
-
-        https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/436'


### PR DESCRIPTION
Based on https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/436 it seems that MA-6 (4) was confused with MA-4 (6).