### PR TITLE
Remove overabundant > and < characters

### DIFF
--- a/openshift-container-platform-3/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-3/policies/AC-Access_Control/component.yaml
@@ -260,9 +260,9 @@
         information within the customer application, and between the customer
         application and external systems. A successful control response will
         need to address the customer information flow control policies,
-        as well as mechanisms in place to enforce those policies.>
+        as well as mechanisms in place to enforce those policies.
 
-        <A review of OpenShift v3 networking can be found in the OpenShift
+        A review of OpenShift v3 networking can be found in the OpenShift
         Architecture guide:
 
         https://docs.openshift.com/container-platform/3.3/architecture/additional_concepts/networking.html


### PR DESCRIPTION
These characters seems to be present only by accident. Nevertheless, they break parsing this text as MDX Markdown.


![mdx_error](https://user-images.githubusercontent.com/6666052/67186090-cf6ba500-f3d6-11e9-810e-395402ba1250.jpg)
