### PR TITLE
Fix typo:

### DIFF
--- a/openshift-container-platform-3/policies/CM-Configuration_Management/component.yaml
+++ b/openshift-container-platform-3/policies/CM-Configuration_Management/component.yaml
@@ -63,7 +63,7 @@
 #       (e.g. Ansible Playbooks) to the central service (e.g. Ansible
 #       Tower).
 #
-- control_key: CM-2(2)
+- control_key: CM-2 (2)
   standard_key: NIST-800-53
   covered_by: []
   implementation_status: planned


### PR DESCRIPTION
Addressing:
```
Could not found reference CM-2(2) in the standard NIST-800-53
```

Interestingly, this bug is only in the master branch. Not in the opencontrols branch.