### PR TITLE
Rework how we handle composite control responses

### DIFF
--- a/coreos-4/policies/AC-Access_Control/component.yaml
+++ b/coreos-4/policies/AC-Access_Control/component.yaml
@@ -898,7 +898,7 @@
         via:
 
         https://github.com/ComplianceAsCode/redhat/issues/811
-    - key: 'Req. 1'
+    - key: c.1
       text: |
         The customer will be responsible for determining the conditions
         under which the system use notification will be displayed. These
@@ -908,7 +908,7 @@
         via:
 
         https://github.com/ComplianceAsCode/redhat/issues/811
-    - key: 'Req. 2'
+    - key: c.2
       text: |
         The customer will be responsible for how the system use notification
         will be verified and how often it should be re-displayed and
@@ -919,7 +919,7 @@
         via:
 
         https://github.com/ComplianceAsCode/redhat/issues/811
-    - key: 'Req. 3'
+    - key: c.3
       text: |
         The customer will be responsible for verifying that the system use
         notification is being displayed as required, either through a

--- a/openshift-container-platform-3/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-3/policies/AC-Access_Control/component.yaml
@@ -442,14 +442,14 @@
         applicable monitoring, recording, or auditing, and authorized usage
         of the system.
         */'
-    - key: 'Req. 1'
+    - key: c.1
       text: |
         '//*
         The customer will be responsible for determining the conditions
         under which the system use notification will be displayed. These
         conditions must be reviewed and accepted by the FedRAMP JAB.
         */'
-    - key: 'Req. 2'
+    - key: c.2
       text: |
         '//*
         The customer will be responsible for how the system use notification
@@ -457,7 +457,7 @@
         re-verified. These conditions must be reviewed an accepted by the
         FedRAMP JAB.
         */'
-    - key: 'Req. 3'
+    - key: c.3
       text: |
         '//*
         The customer will be responsible for verifying that the system use

--- a/openshift-container-platform-3/policies/AU-Audit_and_Accountability/component.yaml
+++ b/openshift-container-platform-3/policies/AU-Audit_and_Accountability/component.yaml
@@ -228,7 +228,7 @@
 #   secondary server is selected from a different region than the primary.
 #   A successful control response will discuss which internet time services
 #   are used by the system.
-    - key: 'Req. 1'
+    - key: b.1
       text: |
         'OpenShift utilizes the time services of the underyling operating
         operating system. This control is not applicable to OpenShift.'
@@ -238,7 +238,7 @@
 #   Windows Domain Controler emulator, or the same time source for that
 #   server. A successful conttrol response will discuss which Internet time
 #   services are for non-Windows systems.
-    - key: 'Req. 2'
+    - key: b.2
       text: |
         'OpenShift utilizes the time services of the underyling operating
         operating system. This control is not applicable to OpenShift.'

--- a/openshift-container-platform-3/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openshift-container-platform-3/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -236,7 +236,7 @@
         boards, TV conference cameras, and remote video systems. This control
         is not applicable because Red Hat OpenShift Container Platform is not
         a collaborative computing device.'
-    - key: Req. 1
+    - key: b.1
       text: |
         'Examples of collaborative computing devices include networked white
         boards, TV conference cameras, and remote video systems. This control

--- a/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
@@ -579,14 +579,14 @@
         applicable monitoring, recording, or auditing, and authorized usage
         of the system.
         */'
-    - key: 'Req. 1'
+    - key: c.1
       text: |
         '//*
         The customer will be responsible for determining the conditions
         under which the system use notification will be displayed. These
         conditions must be reviewed and accepted by the FedRAMP JAB.
         */'
-    - key: 'Req. 2'
+    - key: c.2
       text: |
         '//*
         The customer will be responsible for how the system use notification
@@ -594,7 +594,7 @@
         re-verified. These conditions must be reviewed an accepted by the
         FedRAMP JAB.
         */'
-    - key: 'Req. 3'
+    - key: c.3
       text: |
         '//*
         The customer will be responsible for verifying that the system use

--- a/openshift-container-platform-4/policies/AU-Audit_and_Accountability/component.yaml
+++ b/openshift-container-platform-4/policies/AU-Audit_and_Accountability/component.yaml
@@ -228,7 +228,7 @@
 #   secondary server is selected from a different region than the primary.
 #   A successful control response will discuss which internet time services
 #   are used by the system.
-    - key: 'Req. 1'
+    - key: b.1
       text: |
         'OpenShift utilizes the time services of the underyling operating
         operating system. This control is not applicable to OpenShift.'
@@ -238,7 +238,7 @@
 #   Windows Domain Controler emulator, or the same time source for that
 #   server. A successful conttrol response will discuss which Internet time
 #   services are for non-Windows systems.
-    - key: 'Req. 2'
+    - key: b.2
       text: |
         'OpenShift utilizes the time services of the underyling operating
         operating system. This control is not applicable to OpenShift.'

--- a/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -236,7 +236,7 @@
         boards, TV conference cameras, and remote video systems. This control
         is not applicable because Red Hat OpenShift Container Platform is not
         a collaborative computing device.'
-    - key: Req. 1
+    - key: b.1
       text: |
         'Examples of collaborative computing devices include networked white
         boards, TV conference cameras, and remote video systems. This control

--- a/openstack-platform-13/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openstack-platform-13/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -277,7 +277,7 @@
         boards, TV conference cameras, and remote video systems. This control
         is not applicable because Red Hat Red Hat OpenStack Platform Container Platform is not
         a collaborative computing device.'
-    - key: Req. 1
+    - key: b.1
       text: |
         'Examples of collaborative computing devices include networked white
         boards, TV conference cameras, and remote video systems. This control


### PR DESCRIPTION
Req. 1 is actually child of some subsection; and hence we should mark it as such.

Although, current open control file format does not allow us to specify childs
of subsection we can workaround this by repeating the subsection identifier in
the key.

Addressing error when converting opencontrols to oscal.
Following error was found during validation of oscal:
```
coreos-4.xml:828: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': 'ac-8_smt.Req. 1' is not a valid value of the atomic type 'xs:NCName'.
coreos-4.xml:828: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': Warning: No precomputed value available, the value was either invalid or something strange happend.
coreos-4.xml:839: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': 'ac-8_smt.Req. 2' is not a valid value of the atomic type 'xs:NCName'.
coreos-4.xml:839: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': Warning: No precomputed value available, the value was either invalid or something strange happend.
coreos-4.xml:851: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': 'ac-8_smt.Req. 3' is not a valid value of the atomic type 'xs:NCName'.
coreos-4.xml:851: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': Warning: No precomputed value available, the value was either invalid or something strange happend.
```