### PR TITLE
Add missing yaml attribute

### DIFF
--- a/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
@@ -19,6 +19,7 @@
       text: |
         AC-1(a) is an organizational control outside the scope of OpenShift configuration.
     - key: b
+      text: |
         AC-1(b) is an organizational control outside the scope of OpenShift configuration.
 
 - control_key: AC-2


### PR DESCRIPTION
Addressing failure when converting this to oscal.
```
  $ oscalkit convert opencontrol https://github.com/ComplianceAsCode/redhat output/
  $ oscalkit validate output/*
  output/openshift-container-platform-4.xml:47: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': 'ac-1_stmt.b AC-1(b) is an organizational control outside the scope of OpenShift configuration.' is not a valid value of the atomic type 'xs:NCName'.
  output/openshift-container-platform-4.xml:47: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement', attribute 'statement-id': Warning: No precomputed value available, the value was either invalid or something strange happend.
  output/openshift-container-platform-4.xml fails to validate
```

This currently blocks oscal coversion.