### PR TITLE
No need to define CA-7 (c) twice

### DIFF
--- a/virtualization-host/policies/CA-Security_Assessment_and_Authorization/component.yaml
+++ b/virtualization-host/policies/CA-Security_Assessment_and_Authorization/component.yaml
@@ -126,10 +126,6 @@
       text: |
         'This control reflects organizational procedures/policies, and is not
         applicable to the configuration of Red Hat Virtualization Host (RHVH).'
-    - key: c
-      text: |
-        'This control reflects organizational procedures/policies, and is not
-        applicable to the configuration of Red Hat Virtualization Host (RHVH).'
     - key: e
       text: |
         'This control reflects organizational procedures/policies, and is not


### PR DESCRIPTION
One instance is more than enough.

Addressing:

    $ oscalkit convert opencontrol https://github.com/ComplianceAsCode/redhat output/
    $ oscalkit validate output/*
    output/virtualization-host.xml:860: element statement: Schemas validity error : Element '{http://csrc.nist.gov/ns/oscal/1.0}statement': Duplicate key-sequence ['ca-7_stmt.c'] in unique identity-constraint '{http://csrc.nist.gov/ns/oscal/1.0}implemented-requirement-statement-keys'.
    output/virtualization-host.xml fails to validate