### PR TITLE
COS OCP SC-2 main control

### DIFF
--- a/coreos-4/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/coreos-4/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -20,18 +20,11 @@
 - control_key: SC-2
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        The customer is responsible for separating user functionality
-        including user interface services) from information system management
-        functionality. A successful control response will indicate how user
-        and management functionality access is separated.
-
-        A complete control response is planned. Engineering progress can be
-        tracked via:
-
-        https://issues.redhat.com/browse/CMP-429
+        CoreOS separates user functionality and administration functionality with the use of
+        standard Linux user and group permission configuration.
 
 - control_key: SC-2 (1)
   standard_key: NIST-800-53

--- a/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -20,18 +20,13 @@
 - control_key: SC-2
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        The customer is responsible for separating user functionality
-        including user interface services) from information system management
-        functionality. A successful control response will indicate how user
-        and management functionality access is separated.
-
-        A complete control response is planned. Engineering progress can be
-        tracked via:
-
-        https://issues.redhat.com/browse/CMP-429
+        Application partitioning is implemented within OpenShift configuration by
+        enforcement of Role Based Access Control (RBAC) objects. RBAC objects support
+        separation of user functionality from admin functionality per project, and
+        supports separation of project admin functionality from OpenShift admin functionality.
 
 - control_key: SC-2 (1)
   standard_key: NIST-800-53


### PR DESCRIPTION
set status 'complete'
This control is IS specific, both COS and OCP allow for the distinction between user functionality and administrative functionality.