### PR TITLE
OCP COS CM-4(2)

### DIFF
--- a/coreos-4/policies/CM-Configuration_Management/component.yaml
+++ b/coreos-4/policies/CM-Configuration_Management/component.yaml
@@ -281,9 +281,15 @@
 - control_key: CM-4 (2)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: partial
+  implementation_status: not applicable
   narrative:
     - text: |
+        Verification of security function implementation and status is an organizational
+        policy and procedure control.
+        Normal Linux security function testing (SELinux, firewalld, users and groups, etc)
+        is sufficient to demonstrate functionality is in place following an operation
+        of installing changed code.
+        
         A complete control response is planned. Engineering progress can be
         tracked via:
 

--- a/openshift-container-platform-4/policies/CM-Configuration_Management/component.yaml
+++ b/openshift-container-platform-4/policies/CM-Configuration_Management/component.yaml
@@ -281,9 +281,13 @@
 - control_key: CM-4 (2)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: partial
+  implementation_status: not applicable
   narrative:
     - text: |
+        Verification of security function implementation and status is an organizational
+        policy and procedure control. This functionality is outside the scope of OpenShift
+        configuration.
+
         A complete control response is planned. Engineering progress can be
         tracked via:
 


### PR DESCRIPTION
Status and text update.
Control is organizational, NIST status is not applicable. Demonstration of efficacy of this control is the sole responsibility of the client, even if the implemented COS/OCP system(s) is/are defined by the client to be in scope.