### PR TITLE
OCP4: Add response for SC-8(2)

### DIFF
--- a/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -594,13 +594,12 @@
 - control_key: SC-8 (2)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        To assist with this organizational control, documentation is being
-        planned. Progress can be tracked via:
+        OpenShift uses a FIPS compliant TLS library. [1]
 
-        https://issues.redhat.com/browse/CMP-492
+        [1] https://docs.openshift.com/container-platform/4.7/installing/installing-fips.html
 
 - control_key: SC-8 (3)
   standard_key: NIST-800-53


### PR DESCRIPTION
There's not much we can do on that side except rely on Linux's
networking stack and on our FIPS compliant libraries.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>