### PR TITLE
OCP4: Add comments to responses to indicate that the platform meets the control by default

### DIFF
--- a/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -23,11 +23,12 @@
   implementation_status: complete
   narrative:
     - text: |
-        OpenShift uses the concept of namespaces or projects to ensure
-        workload isolation. The OpenShift platform comes with several
-        default projects that start with the "openshift-" prefix. [1] Such
-        projects, host functionality that's critical for the cluster's
-        operations. Only Cluser Administrators have access to these namespaces,
+        This is inherently met by OpenShift since uses the concept of
+        namespaces or projects to ensure workload isolation. The
+        OpenShift platform comes with several default projects that
+        start with the "openshift-" prefix. [1] Such projects, host
+        functionality that's critical for the cluster's operations.
+        Only Cluser Administrators have access to these namespaces,
         which ensures that regular users don't hace access to cluster
         management functionality.
 
@@ -44,11 +45,12 @@
   implementation_status: complete
   narrative:
     - text: |
-        OpenShift uses the concept of namespaces or projects to ensure
-        workload isolation. The OpenShift platform comes with several
-        default projects that start with the "openshift-" prefix. [1] Such
-        projects, host functionality that's critical for the cluster's
-        operations. Only Cluser Administrators have access to these namespaces,
+        This is inherently met by OpenShift since uses the concept of
+        namespaces or projects to ensure workload isolation. The
+        OpenShift platform comes with several default projects that
+        start with the "openshift-" prefix. [1] Such projects, host
+        functionality that's critical for the cluster's operations.
+        Only Cluser Administrators have access to these namespaces,
         which ensures that regular users don't hace access to cluster
         management functionality.
 
@@ -65,11 +67,12 @@
   implementation_status: complete
   narrative:
     - text: |
-        OpenShift uses the concept of namespaces or projects to ensure
-        workload isolation. The OpenShift platform comes with several
-        default projects that start with the "openshift-" prefix. [1] Such
-        projects, host functionality that's critical for the cluster's
-        operations. Only Cluser Administrators have access to these namespaces,
+        This is inherently met by OpenShift since uses the concept of
+        namespaces or projects to ensure workload isolation. The
+        OpenShift platform comes with several default projects that
+        start with the "openshift-" prefix. [1] Such projects, host
+        functionality that's critical for the cluster's operations.
+        Only Cluser Administrators have access to these namespaces,
         which ensures that regular users don't hace access to cluster
         management functionality.
 
@@ -83,6 +86,7 @@
   implementation_status: complete
   narrative:
     - text: |
+        This is inherently met by OpenShift due to its native constructs.
         The customer is responsible for deployment utilizing namespaces,
         host roles and other features as well as policies and procedures
         to implement and ensure continued isolation of security functions
@@ -124,6 +128,7 @@
   implementation_status: not applicable
   narrative:
     - text: |
+        This is inherently met by OpenShift due to its native constructs.
         Isolation of non-security functions can be achieved by a
         combination of features already included in the platform.
 
@@ -141,6 +146,7 @@
   implementation_status: not applicable
   narrative:
     - text: |
+        This is inherently met by OpenShift due to its native constructs.
         Isolation of security functions can be achieved by a
         combination of features already included in the platform.
 
@@ -169,6 +175,7 @@
   implementation_status: complete
   narrative:
     - text: |
+        This is inherently met by OpenShift due to its native constructs.
         OpenShift namespaces/projects are used to isolate resources
         in the cluster. If a Secret or a ConfigMap object exists
         in the cluster, it will only be accessible by other resources


### PR DESCRIPTION
We'll use this in our automation to detect whether works needs to be
done (or not).

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>