### PR TITLE
OCP: AC-6 clarifications

### DIFF
--- a/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
@@ -837,22 +837,30 @@
 - control_key: AC-6
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        A control response is planned. Progress can be tracked via:
+        This control is inherently met through the combination of Role-based
+        Access Control for both user and system accounts by dividing the
+        roles and assigning them via RBAC to the appropriate accounts,
+        plus defaulting to the restricted SCC.
 
-        https://issues.redhat.com/browse/CMP-115
+        Documentation on the OpenShift RBAC capabilities can be found at
+        https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+        Documentation on the OpenShift SCCs can be found at
+        https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html
 
 - control_key: AC-6 (1)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        A control response is planned. Progress can be tracked via:
-
-        https://issues.redhat.com/browse/CMP-219
+        This control is inherently met because OpenShift requires the
+        membership in the cluster-admin role in order to change security
+        functions or security relevant information by default. Other
+        finer-grained access control can be configured using RBAC:
+        https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
 
 - control_key: AC-6 (2)
   standard_key: NIST-800-53
@@ -962,18 +970,11 @@
 - control_key: AC-6 (10)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        The customer will be responsible for ensuring that non-privileged
-        users cannot execute privileged functions. A successful control
-        response will need to discuss the use of centralized authentication
-        and authorization and any other means of enforcement of privilege
-        levels.
-
-        A control response is planned. Progress can be tracked via:
-
-        https://issues.redhat.com/browse/CMP-123
+        This control is inherently met through the use of Role-based Access Control
+        and SCCs.
 
 - control_key: AC-7
   standard_key: NIST-800-53

--- a/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
@@ -865,7 +865,7 @@
 - control_key: AC-6 (2)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: not applicable
   narrative:
     - text: |
         This is an organizational/procedural control outside the scope of
@@ -882,9 +882,9 @@
         to sudo in Linux. Users will have to completely logout/login when
         requiring privilege escalation between accounts.
 
-        A control response is planned. Progress can be tracked via:
-
-        https://issues.redhat.com/browse/CMP-220
+        It is recommended to grant the cluster-admin clusterrole
+        to a user or a group backed by an IDP and subsequently
+        remove the kubeadmin user as described in https://docs.openshift.com/container-platform/latest/authentication/remove-kubeadmin.html
 
 - control_key: AC-6 (3)
   standard_key: NIST-800-53
@@ -909,12 +909,12 @@
 - control_key: AC-6 (5)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: not applicable
   narrative:
     - text: |
-        A control response is planned. Progress can be tracked via:
-
-        https://issues.redhat.com/browse/CMP-118
+        Restricting privileged accounts to organization-defined personnel
+        or roles is outside the scope of OpenShift configuration, therefore
+        AC-6(5) is an organizational control.
 
 - control_key: AC-6 (6)
   standard_key: NIST-800-53

--- a/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
@@ -955,17 +955,20 @@
 - control_key: AC-6 (9)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
-        The customer will be responsible for auditing the execution of
-        privileged functions. A successful control response will need
-        to relate this requirement to the general auditing requirements
-        of the AU control family.
+        OpenShift performs audit logging by default, which makes this
+        control inherently met.
 
-        A control response is planned. Progress can be tracked via:
+        What constitutes an action by an admin role must be synthetized in a
+        SIEM, though. OCP audit logs do specify the RBAC rule that allowed the action
+        and the identity that requested the action.
 
-        https://issues.redhat.com/browse/CMP-122
+        See https://docs.openshift.com/container-platform/latest/security/audit-log-view.html
+        for documentation on how to view the audit logs and
+        https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html
+        for information on configuring the audit logging.
 
 - control_key: AC-6 (10)
   standard_key: NIST-800-53


### PR DESCRIPTION
Mostly easy

OCP: AC-6(9) is inherently met

What constitutes an action by an admin role must be synthetized in a SIEM.
The audit logs do specify the RBAC rule that allowed the action and the
identity that requested the action.

OCP: AC-6(2) and (5) are organizational controls

The only thing we can do is to prevent kubeadmin from being used by 
multiple people.

OCP: AC-6, -6(1) and and -6(10) are inherently met

In all three cases, RBAC, SCC and for 6(1) the cluster-admin role in
particular are enabled by default and neither RBAC or SCC are optional.