### PR TITLE
IA-2(8): OCP authentication is replay-resistant as long as TLS is enforced

### DIFF
--- a/openshift-container-platform-4/policies/IA-Identification_and_Authentication/component.yaml
+++ b/openshift-container-platform-4/policies/IA-Identification_and_Authentication/component.yaml
@@ -151,9 +151,16 @@
   implementation_status: complete
   narrative:
     - text: |-
-        A control response is planned. Engineering progress can be tracked via:
+        OpenShift offers support for replay-resistant authentication
+        mechanisms, both for OpenShift console and 3rd party
+        authentication. Third party identity providers configured for
+        modern TLS is supported by OpenShift.
 
-        https://issues.redhat.com/browse/CMP-573
+        Please see the specific identity provider documentation:
+        https://docs.openshift.com/container-platform/latest/authentication/understanding-authentication.html
+
+        When using the LDAP provider, care must be taken to not set
+        the "insecure" flag so that TLS is used.
 
 - control_key: IA-2 (9)
   standard_key: NIST-800-53


### PR DESCRIPTION
The control itself says:
Replay- resistant techniques include, for example, protocols that use
nonces or challenges such as Transport Layer Security (TLS) and time
synchronous or challenge-response one-time authenticators.

So as long as we enfornce the use of TLS, we should be good.