### PR TITLE
IA-2(5): No group authenticators except for kubeadmin, let's remove kubeadmin

### DIFF
--- a/openshift-container-platform-4/policies/IA-Identification_and_Authentication/component.yaml
+++ b/openshift-container-platform-4/policies/IA-Identification_and_Authentication/component.yaml
@@ -118,12 +118,15 @@
 - control_key: IA-2 (5)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |-
-        A control response is planned. Engineering progress can be tracked via:
+        It is recommended to grant the cluster-admin clusterrole
+        to a user or a group backed by an IDP and subsequently
+        remove the kubeadmin user as described in https://docs.openshift.com/container-platform/latest/authentication/remove-kubeadmin.html
 
-        https://issues.redhat.com/browse/CMP-314
+        This would get rid of the only shared account normally present
+        in Red Hat OpenShift and map users in the organization to system users.
 
 - control_key: IA-2 (6)
   standard_key: NIST-800-53


### PR DESCRIPTION
The control says:
The organization requires individuals to be authenticated with an
individual authenticator when a group authenticator is employed.

The best way to ensure the control is met is through removing kubeadmin
and setting up an IDP, then all user identities can be tied into OCP
identities and no group authentication is performed at all.