### PR TITLE
OCP4: AC-17(2) is not applicable to openshift

### DIFF
--- a/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
+++ b/openshift-container-platform-4/policies/AC-Access_Control/component.yaml
@@ -1443,7 +1443,7 @@
 - control_key: AC-17 (3)
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: complete
+  implementation_status: not applicable
   narrative:
     - text: |
         The customer will be responsible for requiring remote access


### PR DESCRIPTION
Setting up a bastion host is outside the scope of OCP configuration.