### PR TITLE
OCP SA: Add a blob that explicitly says that a control is addressed via documenattion

### DIFF
--- a/openshift-container-platform-4/policies/SA-System_and_Services_Acquisition/component.yaml
+++ b/openshift-container-platform-4/policies/SA-System_and_Services_Acquisition/component.yaml
@@ -167,6 +167,8 @@
         which can be downloaded from:
         https://access.redhat.com/articles/5059881
 
+        Therefore this control is addressed via documentation.
+
 ##
 ## Developers note on SA-4 (2):
 ##  This control differs from SA-4 (1) in that implementation
@@ -192,6 +194,8 @@
           https://docs.openshift.com/container-platform/4.7/rest_api/index.html
         Finally, everything is open source:
           https://github.com/openshift/
+
+        Therefore this control is addressed via documentation.
 
 ##
 ## Developers note on SA-4 (3):
@@ -338,6 +342,8 @@
         An overview of all the networking requirements can be
         found at:
         https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-network-user-infra_installing-bare-metal-network-customizations
+
+        Therefore this control is addressed via documentation.
 
         As part of the compliance checks performed by the Compliance Operator,
         Red Hat OpenShift components such as the kubelet are checked for using


### PR DESCRIPTION
This blob will be used by our documentation to mark the control as not
needing additional work.