### PR TITLE
OCP4: CM-11: User-installed software

### DIFF
--- a/openshift-container-platform-4/policies/CM-Configuration_Management/component.yaml
+++ b/openshift-container-platform-4/policies/CM-Configuration_Management/component.yaml
@@ -974,26 +974,47 @@
 - control_key: CM-11
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - key: a
       text: |
-        A complete control response is planned. Progress can be
-        tracked via:
-
-        https://issues.redhat.com/browse/CMP-285
+        Developing, documenting, and disseminating an organizational policy
+        governing the installation  of software by users
+        is outside the scope of OpenShift configuration.
     - key: b
       text: |
-        A complete control response is planned. Progress can be
-        tracked via:
+        Red Hat OpenShift allows for configuring the platform in such a way
+        that only signed containers will be accepted for scheduling. [1] [2]
 
-        https://issues.redhat.com/browse/CMP-285
+        Red Hat signs the images provided for running the platform, as well
+        as the base images that are usable for building other workloads.
+
+        Customers should be careful to enforce image signing on their own images.
+
+        In addition, Red Hat OpenShift allows limiting he container image
+        registries from which normal users can import images by setting
+        allowedRegistriesForImport[3]
+
+        [1] https://docs.openshift.com/container-platform/4.7/security/container_security/security-container-signature.html
+        [2] https://docs.openshift.com/container-platform/4.7/security/container_security/security-deploy.html#security-deploy-image-sources_security-deploy
+        [3] https://docs.openshift.com/container-platform/4.7/openshift_images/image-configuration.html
     - key: c
       text: |
-        A complete control response is planned. Progress can be
-        tracked via:
+        Red Hat OpenShift allows for configuring the platform in such a way
+        that only signed containers will be accepted for scheduling. [1] [2]
 
-        https://issues.redhat.com/browse/CMP-285
+        Red Hat signs the images provided for running the platform, as well
+        as the base images that are usable for building other workloads.
+
+        Customers should be careful to enforce image signing on their own images.
+
+        In addition, Red Hat OpenShift allows limiting he container image
+        registries from which normal users can import images by setting
+        allowedRegistriesForImport[3]
+
+        [1] https://docs.openshift.com/container-platform/4.7/security/container_security/security-container-signature.html
+        [2] https://docs.openshift.com/container-platform/4.7/security/container_security/security-deploy.html#security-deploy-image-sources_security-deploy
+        [3] https://docs.openshift.com/container-platform/4.7/openshift_images/image-configuration.html
 
 - control_key: CM-11 (1)
   standard_key: NIST-800-53


### PR DESCRIPTION
The organization:
a. Establishes [Assignment: organization-defined policies] governing the installation of software by users;
b. Enforces software installation policies through [Assignment: organization-defined methods]; and
c. Monitors policy compliance at [Assignment: organization-defined frequency].

Regarding the monitoring, the control says: "Policy enforcement methods
include procedural methods (e.g., periodic examination of user accounts),
automated methods (e.g., configuration settings implemented on organizational
information systems), or both." which makes me think that periodically running
the checks that look if signing is enforced and if registries have been
configured is enough. It would be nice to write the openscap rule so that
the list of allowed registries is configurable, that would provide nicer auditing.