### PR TITLE
Tag SA-10 and SC-22 as inherently met

### DIFF
--- a/openshift-container-platform-4/policies/SA-System_and_Services_Acquisition/component.yaml
+++ b/openshift-container-platform-4/policies/SA-System_and_Services_Acquisition/component.yaml
@@ -582,7 +582,7 @@
         Red Hat uses git and github for development, so all changes including
         their authorship are tracked in SCMs and identifiable with a hash.
         Any downstream-specific changes are tracked in a special "midstream"
-        repository.
+        repository. This makes the control inherently met.
 
     - key: b
       text: |

--- a/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
+++ b/openshift-container-platform-4/policies/SC-Systems_and_Communications_Protection/component.yaml
@@ -1163,7 +1163,7 @@
 - control_key: SC-22
   standard_key: NIST-800-53
   covered_by: []
-  implementation_status: planned
+  implementation_status: complete
   narrative:
     - text: |
         OpenShift's internal DNS implementation inherently meets this


### PR DESCRIPTION
- SA-10 was missing the blob
- SC-22 was not marked as complete, which the dashboard script expects